### PR TITLE
Fixed image null error

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -179,7 +179,7 @@
             var httpreq = require('httpreq');
             var coverFilepath = filepath + ".jpg";
             var t = this.track;
-            var url = this.Spotify.sourceUrls.LARGE + (t.album.coverGroup.image[2] ? t.album.coverGroup.image[2].uri : '').replace("undefined","");
+            var url = this.Spotify.sourceUrls.LARGE + (t == null ? t.album.coverGroup.image[2].uri : '').replace("undefined","");
             httpreq.download(
                 url, 
                 coverFilepath, 


### PR DESCRIPTION
TypeError: Cannot read property 'image' of null
https://github.com/kirashi3/spotify-playlist-downloader-with-windows-gui/commit/46249f393a94d1f866493055c0e3fd860829bcbb
